### PR TITLE
Fix: Exclude bundled packages from externization

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -30,16 +30,12 @@ const DependencyExtractionPlugin = {
 		const options = build.initialOptions
 		const deps = [ 'wp-element' ];
 
-		build.onResolve( { filter: /^@wordpress\// }, ( args ) => ({
+		build.onResolve( { filter: /^@wordpress\// }, ( args ) => BUNDLED_PACKAGES.includes( args.path ) ? undefined : {
 			path: args.path,
 			namespace: 'wp-globals',
-		}));
+		});
 
 		build.onLoad({ filter: /.*/, namespace: 'wp-globals' }, ( { path } ) => {
-
-			if ( BUNDLED_PACKAGES.includes( path ) ) {
-				return undefined;
-			}
 
 			const package = path.substring(WORDPRESS_NAMESPACE.length)
 			const name = camelCaseDash( package );

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -6,6 +6,7 @@ const json2php = require( 'json2php' );
 const args = process.argv.slice( 2 );
 
 const WORDPRESS_NAMESPACE = '@wordpress/';
+const BUNDLED_PACKAGES = [ '@wordpress/icons', '@wordpress/interface' ];
 
 /**
  * Given a string, returns a new string with dash separators converted to
@@ -35,6 +36,11 @@ const DependencyExtractionPlugin = {
 		}));
 
 		build.onLoad({ filter: /.*/, namespace: 'wp-globals' }, ( { path } ) => {
+
+			if ( BUNDLED_PACKAGES.includes( path ) ) {
+				return undefined;
+			}
+
 			const package = path.substring(WORDPRESS_NAMESPACE.length)
 			const name = camelCaseDash( package );
 


### PR DESCRIPTION
WordPress core does not ship all `@wordpress` dependencies in core and therefore
some packages need to get manually bundled with a plugin.

See: https://github.com/WordPress/gutenberg/blob/trunk/packages/dependency-extraction-webpack-plugin/lib/util.js#L37-L39